### PR TITLE
Add probable authors to each file.

### DIFF
--- a/git_helper.js
+++ b/git_helper.js
@@ -169,6 +169,16 @@ const git_helper = {
           'Authorization': 'Basic ' + btoa(config.username + ':' + config.auth_token)
         }
       } : {}
-    }
+    },
+
+    /** Gets the commits API url given a specific filename.
+     *
+     * @param {String} the file name to retrieve commits for
+     * @return {String} a URL that can be used to fetch commits for that file
+     */
+     getCommitsURLForFile(filename) {
+       return git_helper.getRepoAPIURL(document.location.href) + '/commits?path=' + filename;
+     }
+
 
 };

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
 
   "name": "PRisk",
   "description": "Add risk analysis to git PRs",
-  "version": "0.5.8",
+  "version": "0.6.0",
   "author": "Derrick Schneider <derrick.schneider@opower.com>",
 
   "content_scripts": [

--- a/ui.js
+++ b/ui.js
@@ -62,6 +62,11 @@ const ui = {
         riskIconElem.appendChild(riskImgElem);
         trElem.appendChild(riskIconElem);
       });
+
+     // add in the authors field: people who are good to tag for the file
+     authorsFieldElem = document.createElement('td');
+     authorsFieldElem.setAttribute('id', diff.id + '-' + prisk.constants.PR_DIFF_OWNER_DIV_ID);
+     trElem.appendChild(authorsFieldElem);
     });
 
   },


### PR DESCRIPTION
Find the last 50 commits and determine which
two authors represent the most commits for the
file within that set. Display in UI.

Along the way, refactor the construction of the commits URL to remove duplication.
