### PR TITLE
Do not show owners if there are none.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.DS_Store
+node_modules

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
 
   "name": "PRisk",
   "description": "Add risk analysis to git PRs",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "author": "Derrick Schneider <derrick.schneider@gmail.com>",
 
   "browser_action": {

--- a/prisk.js
+++ b/prisk.js
@@ -146,8 +146,10 @@ const prisk = {
           const topTwo = authorsAndCounts.slice(0,2).map( tuple => tuple[0] );
 
           // now find the authors div and append the text
-          const diffAuthorDiv = document.getElementById(diffElem.id + '-' + prisk.constants.PR_DIFF_OWNER_DIV_ID);
-          diffAuthorDiv.appendChild(document.createTextNode('Owners: ' + topTwo.toString()));
+          if (topTwo.length != 0) { // new file, no owners. todo: this is using a side effect to guess behavior
+            const diffAuthorDiv = document.getElementById(diffElem.id + '-' + prisk.constants.PR_DIFF_OWNER_DIV_ID);
+            diffAuthorDiv.appendChild(document.createTextNode('Owners: ' + topTwo.toString()));
+          }
 
         }, function(commits) { return commits.length < 50; }
       );


### PR DESCRIPTION
Previously, even a file for which no owners could be inferred would
display "Owners:" and nothing. This commit looks for the length of
the top owners, and if it's 0, doesn't display anything.

Also adds .gitignore
